### PR TITLE
Add support for custom stack capture callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ always creates a new error which wraps the original.
  
 You can also add your own additional information.
 
+The default stacktrace mechanism can optionally be disabled or replaced
+with a your own stacktrace function.
+
 Details
 -------
 
@@ -101,18 +104,32 @@ Details
     m = merry.Details(err) // error message and stacktrace
     ```
    
-* Add you're own context info
+* Add your own context info
 
     ```go
     err := merry.New("boom").WithValue("explosive", "black powder")
     ```
-    
+ 
+* Replace default stacktracing with a custom function. This is a global setting.
+
+    ```go
+    merry.RegisterStackCaptureFunc(f)   // Replaces default stack capture func with f
+    merry.RegisterStackCaptureFunc(nil) // Disables stack capture functionality
+    ```
+
+* Unregister custom stack capture function and revert to default stacktracing. This is a global setting.
+
+    ```go
+    merry.UnregisterStackCaptureFunc(f)   // Restores default stack capture functionality
+    ```
+
 Basic Usage
 -----------
 
 The package contains functions for creating new errors with stacks, or adding a stack to `error` 
 instances.  Functions with add context (e.g. `WithValue()`) work on any `error`, and will 
-automatically convert them to merry errors (with a stack) if necessary.
+automatically convert them to merry errors (with a stack) if necessary. Capturing of the stack
+with errors is the default, but can be modified using `RegisterStackCaptureFunc()`/`UnregisterStackCaptureFunc()`.
 
 Functions which get context values from errors also accept `error`, and will return default
 values if the error is not merry, or doesn't have that key attached.
@@ -170,7 +187,7 @@ func main() {
     // Get the location of the error (the first line in the stacktrace)
     file, line := merry.Location(err)
     
-    // Get an HTTP status code for an error.  Defaults to 500.
+    // Get an HTTP status code for an error.  Defaults to 500 for non-nil errors.
     code := merry.HTTPCode(err)
     
 }

--- a/print.go
+++ b/print.go
@@ -9,6 +9,11 @@ import (
 
 // Returns zero values if e has no stacktrace
 func Location(e error) (file string, line int) {
+	if !isDefaultStackCapture() {
+		// If we are not using the default stack capture function,
+		// we don't know how to interpret the stacktrace data
+		return "", 0
+	}
 	s := Stack(e)
 	if len(s) > 0 {
 		sf := goerr.NewStackFrame(s[0])
@@ -21,6 +26,11 @@ func Location(e error) (file string, line int) {
 // Location's result or an empty string if there's
 // no stracktrace.
 func SourceLine(e error) string {
+	if !isDefaultStackCapture() {
+		// If we are not using the default stack capture function,
+		// we don't know how to interpret the stacktrace data
+		return ""
+	}
 	file, line := Location(e)
 	if line != 0 {
 		return fmt.Sprintf("%s:%d", file, line)
@@ -32,6 +42,11 @@ func SourceLine(e error) string {
 // the same way as golangs runtime package.
 // If e has no stacktrace, returns an empty string.
 func Stacktrace(e error) string {
+	if !isDefaultStackCapture() {
+		// If we are not using the default stack capture function,
+		// we don't know how to interpret the stacktrace data
+		return ""
+	}
 	s := Stack(e)
 	if len(s) > 0 {
 		buf := bytes.Buffer{}


### PR DESCRIPTION
This commit partially addresses issue #8.

When a merry error is first created, or first wrapped around an existing
error, a stacktrace is captured. That capturing is currently a hardcoded
internal function of merry. This commit turns the stacktrace function
into a callback. This allows users of merry to:

- remove the callback, to skip capturing stacktraces (for performance)
- replace the callback, to capture a different kind of stacktrace (e.g.
  sentry stacktraces)

The callback is registered globally. It is invoked whenever a new merry
error is created, or when an error was wrapped with a merry error. It is
passed the number of frames to skip, and returns []uintptr containing
the stack trace data.

Possible future enhancements:
Register a custom Stacktrace() function when registering the stack
capture function, so that the Stacktrace() method will continue to work
even with custom stacktraces.