### PR TITLE
Fix "TestSourceLine" cannot passed at windows os

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -414,7 +414,8 @@ func TestSourceLine(t *testing.T) {
 	t.Log(source)
 	assert.NotEqual(t, source, "")
 
-	parts := strings.Split(source, ":")
+	idx := strings.LastIndex(source, ":")
+	parts := []string{source[:idx], source[idx+1:]}
 	assert.Equal(t, len(parts), 2)
 
 	if !strings.HasSuffix(parts[0], "errors_test.go") {


### PR DESCRIPTION
"TestSourceLine" cannot passed at windows.
Bacause in windows, path format is "x://xx/xx", if use strings.Split method, then get 3parts, and strings package no RSplit method, so i use LastIndex method to get line number.