### PR TITLE
Add support for go1.13's implemention of the go 2 errors proposal

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -410,31 +410,11 @@ func Prependf(e error, format string, args ...interface{}) Error {
 //     merry.Is(e3, e1)  // yes it is, because e1 was a cause of e3
 //
 func Is(e error, originals ...error) bool {
-	is := func(e, original error) bool {
-		for {
-			if e == original {
-				return true
-			}
-			if e == nil || original == nil {
-				return false
-			}
-			w, ok := e.(*merryErr)
-			if !ok {
-				return false
-			}
-			e = w.err
-		}
-	}
 	for _, o := range originals {
 		if is(e, o) {
 			return true
 		}
 	}
-	// check cause
-	if c := Cause(e); c != nil {
-		return Is(c, originals...)
-	}
-
 	return false
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go1_12.go
+++ b/go1_12.go
@@ -1,0 +1,16 @@
+// +build !go1.13
+
+package merry
+
+import (
+	errors "golang.org/x/xerrors"
+)
+
+// If using <go1.13, polyfill errors.Is/As with golang.org/x/xerrors
+// xerrors can be removed once <go1.12 support is dropped
+
+// implements Is by delegating to errors
+var is = errors.Is
+
+// implements As by delegating to errors
+var as = errors.As

--- a/go1_13.go
+++ b/go1_13.go
@@ -1,0 +1,14 @@
+// +build go1.13
+
+package merry
+
+import "errors"
+
+// If using >=go1.13, golang.org/x/xerrors is not needed.
+// xerrors can be removed once <go1.12 support is dropped
+
+// implements Is by delegating to errors
+var is = errors.Is
+
+// implements As by delegating to errors
+var as = errors.As

--- a/isas.go
+++ b/isas.go
@@ -1,0 +1,56 @@
+package merry
+
+// Unwrap implements the go2 errors proposal.  Unwrapping a merry error returns the
+// error's cause, same as merry.Cause(err).
+func (e *merryErr) Unwrap() error {
+	return e.Cause()
+}
+
+// merry errors have both a chain of wrapped errors (ending in a root error),
+// as well as a chain of "causes".  merry's public API allows you to traverse
+// the chain of causes, by recursively calling merry.Cause(error), and it allows
+// you to get the root of the wrapped chain of merry errors, via merry.Unwrap(error).
+// There was no public API for traversing the intermediary merryErrs in the chain
+// of wrapped errors, but internal code in the package traverses it by recursively
+// accessing merryErr.err.
+
+// To meet the spirit of the new errors.Is and errors.As functions, those functions
+// need to traverse both the chain of wrapped errors, as well as the chain of
+// causes.  To achieve this, merryErr.Unwrap() returns the
+// error's cause, and noCauseErr.Unwrap() returns the wrapped err.
+
+// This implementation of merryErr.Is() and merryErr.As() casts the receiver
+// as a noCauseErr, then recursively calls errors.Is/As on that.  This will compare
+// the arg to each error in the chain, calling noCauseErr.Unwrap() at each step,
+// which returns the wrapped error.  Once that recursion completes, if a match
+// isn't found, the call unwinds back to the original errors.Is/As call, which
+// is operating on the merryErr.  merryErr.Unwrap() is called, which returns
+// the "cause" error (if any), and recurses on that error's Unwrap() implemention.
+// In a large graph of merry errors with causes that are also merry errors, the
+// recursion will traverse each nodes wrapped errors first, then traverse causes.
+// In other words, it's a depth-first traversal, where wrapped errors are
+// child nodes, and causes are sibling nodes.
+
+type noCauseErr merryErr
+
+func (u *noCauseErr) Unwrap() error {
+	return u.err
+}
+
+func (u *noCauseErr) Error() string {
+	return u.err.Error()
+}
+
+// Is implements the new go 2.0 errors function.  It returns true if
+// the argument equals the current error, any of the errors in the merry
+// wrapper chain, or the cause of the error.  It searches the chain
+// of wrappers first, then tries the error's cause.
+func (e *merryErr) Is(err error) bool {
+	u := (*noCauseErr)(e)
+	return is(u, err)
+}
+
+func (e *merryErr) As(target interface{}) bool {
+	u := (*noCauseErr)(e)
+	return as(u, target)
+}

--- a/isas_test.go
+++ b/isas_test.go
@@ -1,0 +1,62 @@
+package merry
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMerryErr_Unwrap(t *testing.T) {
+	e1 := New("blue")
+	c1 := New("fm")
+	e2 := Prepend(e1, "color").WithCause(c1)
+
+	assert.Equal(t, c1, e2.(*merryErr).Unwrap())
+}
+
+func TestMerryErr_Is(t *testing.T) {
+	e1 := New("blue")
+	c1 := New("fm")
+	e2 := Prepend(e1, "color").WithCause(c1)
+	e3 := New("red")
+
+	assert.True(t, is(e2, e2))
+	assert.True(t, is(e2, e1))
+	assert.True(t, is(e2, c1))
+	assert.False(t, is(e2, e3))
+}
+
+type redError int
+
+func (*redError) Error() string {
+	return "red error"
+}
+
+func TestMerryErr_As(t *testing.T) {
+	e1 := New("blue error")
+
+	var rerr *redError
+	assert.False(t, as(e1, &rerr))
+	assert.Nil(t, rerr)
+
+	rr := redError(3)
+	e2 := Wrap(&rr)
+
+	assert.True(t, as(e2, &rerr))
+	assert.Equal(t, &rr, rerr)
+}
+
+func BenchmarkIs(b *testing.B) {
+	root := New("root")
+	err := root
+	for i := 0; i < 10; i++ {
+		err = New("wrapper").WithCause(err)
+		for j := 0; j < 10; j++ {
+			err = Prepend(err, "wrapped")
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		assert.True(b, Is(err, root))
+	}
+}


### PR DESCRIPTION
merry errors need to implement Is, As, and Unwrap, to be compatible with go1.13's errors.Is and errors.As functions.  The implementations here ensure that those functions traverse both merry's wrapped errors, as well as "cause" errors.